### PR TITLE
Don't run code that fails on OS X. Fixes #295

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -27,7 +27,9 @@ MainWindow::MainWindow(ConfigHelper *confHelper, QWidget *parent) :
     ui->setupUi(this);
 
     //setup Settings menu
-    ui->menuSettings->addAction(ui->toolBar->toggleViewAction());
+#ifndef Q_OS_DARWIN
+	ui->menuSettings->addAction(ui->toolBar->toggleViewAction());
+#endif
 
     //initialisation
     model = new ConnectionTableModel(this);


### PR DESCRIPTION
After a lot of debugging and testing on OS X with Xcode, I finally found the line of code that was causing ss-qt5 to crash on Mac OS X.

I'm not sure what this line does, or its purpose (I don't know anything about QT5), so I just chose to ignore it on OS X for now. If anybody knows of a better solution then feel free to update it.

