### PR TITLE
Use QLocalSocket instead to implement single instance

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,46 +25,6 @@ static void onSignalRecv(int sig)
     if (sig == SIGINT || sig == SIGTERM) qApp->quit();
 }
 
-bool isConflictWithPreviousInstance(QApplication &a)
-{
-    QSharedMemory *sharedMem = new QSharedMemory("Shadowsocks-Qt5", &a);
-    qint64 pid = -1;
-
-    if (sharedMem->create(sizeof(qint64))) {
-        pid = QCoreApplication::applicationPid();
-        if (sharedMem->lock()) {
-            *reinterpret_cast<qint64*>(sharedMem->data()) = pid;
-            sharedMem->unlock();
-            // we can only run a new instance of ss-qt5 if the shared memory
-            // is created and written successfully
-            return false;
-        } else {
-            qCritical() << sharedMem->errorString();
-        }
-    } else {
-        if (!sharedMem->attach(QSharedMemory::ReadOnly)) {
-            qCritical() << sharedMem->errorString();
-        } else if (sharedMem->lock()) {
-            pid = *reinterpret_cast<qint64*>(sharedMem->data());
-            sharedMem->unlock();
-        } else {
-            qCritical() << sharedMem->errorString();
-        }
-
-#ifdef Q_OS_UNIX
-        //try to send a signal to show previous process's main window
-        if (kill(pid, SIGUSR1) != 0) {
-            QString errStr = QObject::tr("Failed to communicate with previously running instance of Shadowsocks-Qt5 (PID: %1). It might already crashed.").arg(pid);
-            QMessageBox::critical(mainWindow, QObject::tr("Error"), errStr);
-        }
-#else
-        QMessageBox::critical(mainWindow, QObject::tr("Error"), QObject::tr("Another instance of Shadowsocks-Qt5 (PID: %1) is already running.").arg(pid));
-#endif
-    }
-    // Can't run a new instance under all other situations
-    return true;
-}
-
 void setupApplication(QApplication &a)
 {
     signal(SIGINT, onSignalRecv);
@@ -124,12 +84,12 @@ int main(int argc, char *argv[])
     }
     ConfigHelper conf(configFile);
 
-    if (conf.isOnlyOneInstance() && isConflictWithPreviousInstance(a)) {
-        return -1;
-    }
-
     MainWindow w(&conf);
     mainWindow = &w;
+
+    if (conf.isOnlyOneInstance() && w.isInstanceRunning()) {
+        return -1;
+    }
 
     w.startAutoStartConnections();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -560,17 +560,17 @@ void MainWindow::initSingleInstance()
     instanceRunning = false;
 
     QString username = qgetenv("USER");
-    if (username.isEmpty()){
+    if (username.isEmpty()) {
         username = qgetenv("USERNAME");
     }
 
     QString serverName = QCoreApplication::applicationName() + "_" + username;
     QLocalSocket socket;
     socket.connectToServer(serverName);
-    if(socket.waitForConnected(500)){
+    if (socket.waitForConnected(500)) {
         instanceRunning = true;
-        if(configHelper->isOnlyOneInstance()){
-            qWarning()<<"A instance from the same user is already running";
+        if (configHelper->isOnlyOneInstance()) {
+            qWarning() << "A instance from the same user is already running";
         }
         socket.write(serverName.toUtf8());
         socket.waitForBytesWritten();
@@ -580,11 +580,12 @@ void MainWindow::initSingleInstance()
     /* Cann't connect to server, indicating it's the first instance of the user */
     instanceServer = new QLocalServer(this);
     instanceServer->setSocketOptions(QLocalServer::UserAccessOption);
-    connect(instanceServer, SIGNAL(newConnection()), this,SLOT(onSingleInstanceConnect()));
-    if(instanceServer->listen(serverName)){
+    connect(instanceServer, &QLocalServer::newConnection,
+            this,&MainWindow::onSingleInstanceConnect);
+    if (instanceServer->listen(serverName)) {
         /* Remove server in case of crashes */
-        if(instanceServer->serverError() == QAbstractSocket::AddressInUseError\
-                &&QFile::exists(instanceServer->serverName())){
+        if (instanceServer->serverError() == QAbstractSocket::AddressInUseError &&
+                QFile::exists(instanceServer->serverName())) {
             QFile::remove(instanceServer->serverName());
             instanceServer->listen(serverName);
         }
@@ -594,19 +595,19 @@ void MainWindow::initSingleInstance()
 void MainWindow::onSingleInstanceConnect()
 {
     QLocalSocket *socket = instanceServer->nextPendingConnection();
-    if(!socket){
+    if (!socket) {
         return;
     }
 
-    if(socket->waitForReadyRead(1000)){
+    if (socket->waitForReadyRead(1000)) {
         QString username = qgetenv("USER");
-        if (username.isEmpty()){
+        if (username.isEmpty()) {
             username = qgetenv("USERNAME");
         }
 
         QByteArray byteArray = socket->readAll();
         QString magic(byteArray);
-        if(magic == QCoreApplication::applicationName() + "_" + username){
+        if (magic == QCoreApplication::applicationName() + "_" + username) {
             show();
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -15,6 +15,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QCloseEvent>
+#include <QLocalSocket>
 #include <botan/version.h>
 
 MainWindow::MainWindow(ConfigHelper *confHelper, QWidget *parent) :
@@ -24,11 +25,13 @@ MainWindow::MainWindow(ConfigHelper *confHelper, QWidget *parent) :
 {
     Q_ASSERT(configHelper);
 
+    initSingleInstance();
+
     ui->setupUi(this);
 
     //setup Settings menu
 #ifndef Q_OS_DARWIN
-	ui->menuSettings->addAction(ui->toolBar->toggleViewAction());
+    ui->menuSettings->addAction(ui->toolBar->toggleViewAction());
 #endif
 
     //initialisation
@@ -118,10 +121,10 @@ MainWindow::MainWindow(ConfigHelper *confHelper, QWidget *parent) :
 
     connect(ui->connectionView, &QTableView::clicked,
             this, static_cast<void (MainWindow::*)(const QModelIndex&)>
-                  (&MainWindow::checkCurrentIndex));
+            (&MainWindow::checkCurrentIndex));
     connect(ui->connectionView, &QTableView::activated,
             this, static_cast<void (MainWindow::*)(const QModelIndex&)>
-                  (&MainWindow::checkCurrentIndex));
+            (&MainWindow::checkCurrentIndex));
     connect(ui->connectionView, &QTableView::doubleClicked,
             this, &MainWindow::onEdit);
 
@@ -525,7 +528,7 @@ void MainWindow::setupActionIcon()
     ui->actionEdit->setIcon(QIcon::fromTheme("document-edit",
                             QIcon::fromTheme("accessories-text-editor")));
     ui->actionShare->setIcon(QIcon::fromTheme("document-share",
-                     QIcon::fromTheme("preferences-system-sharing")));
+                             QIcon::fromTheme("preferences-system-sharing")));
     ui->actionTestLatency->setIcon(QIcon::fromTheme("flag",
                                    QIcon::fromTheme("starred")));
     ui->actionImportGUIJson->setIcon(QIcon::fromTheme("document-import",
@@ -542,7 +545,70 @@ void MainWindow::setupActionIcon()
     ui->actionViewLog->setIcon(QIcon::fromTheme("view-list-text",
                                QIcon::fromTheme("text-x-preview")));
     ui->actionGeneralSettings->setIcon(QIcon::fromTheme("configure",
-                                   QIcon::fromTheme("preferences-desktop")));
+                                       QIcon::fromTheme("preferences-desktop")));
     ui->actionReportBug->setIcon(QIcon::fromTheme("tools-report-bug",
                                  QIcon::fromTheme("help-faq")));
+}
+
+bool MainWindow::isInstanceRunning() const
+{
+    return instanceRunning;
+}
+
+void MainWindow::initSingleInstance()
+{
+    instanceRunning = false;
+
+    QString username = qgetenv("USER");
+    if (username.isEmpty()){
+        username = qgetenv("USERNAME");
+    }
+
+    QString serverName = QCoreApplication::applicationName() + "_" + username;
+    QLocalSocket socket;
+    socket.connectToServer(serverName);
+    if(socket.waitForConnected(500)){
+        instanceRunning = true;
+        if(configHelper->isOnlyOneInstance()){
+            qWarning()<<"A instance from the same user is already running";
+        }
+        socket.write(serverName.toUtf8());
+        socket.waitForBytesWritten();
+        return;
+    }
+
+    /* Cann't connect to server, indicating it's the first instance of the user */
+    instanceServer = new QLocalServer(this);
+    instanceServer->setSocketOptions(QLocalServer::UserAccessOption);
+    connect(instanceServer, SIGNAL(newConnection()), this,SLOT(onSingleInstanceConnect()));
+    if(instanceServer->listen(serverName)){
+        /* Remove server in case of crashes */
+        if(instanceServer->serverError() == QAbstractSocket::AddressInUseError\
+                &&QFile::exists(instanceServer->serverName())){
+            QFile::remove(instanceServer->serverName());
+            instanceServer->listen(serverName);
+        }
+    }
+}
+
+void MainWindow::onSingleInstanceConnect()
+{
+    QLocalSocket *socket = instanceServer->nextPendingConnection();
+    if(!socket){
+        return;
+    }
+
+    if(socket->waitForReadyRead(1000)){
+        QString username = qgetenv("USER");
+        if (username.isEmpty()){
+            username = qgetenv("USERNAME");
+        }
+
+        QByteArray byteArray = socket->readAll();
+        QString magic(byteArray);
+        if(magic == QCoreApplication::applicationName() + "_" + username){
+            show();
+        }
+    }
+    delete socket;
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -21,6 +21,7 @@
 
 #include <QMainWindow>
 #include <QSortFilterProxyModel>
+#include <QLocalServer>
 #include "connectiontablemodel.h"
 #include "confighelper.h"
 #include "statusnotifier.h"
@@ -38,6 +39,7 @@ public:
     ~MainWindow();
 
     void startAutoStartConnections();
+    bool isInstanceRunning() const;
 
 private:
     Ui::MainWindow *ui;
@@ -46,6 +48,10 @@ private:
     QSortFilterProxyModel *proxyModel;
     ConfigHelper *configHelper;
     StatusNotifier *notifier;
+
+    QLocalServer* instanceServer;
+    bool instanceRunning;
+    void initSingleInstance();
 
     void newProfile(Connection *);
     void editRow(int row);
@@ -84,6 +90,7 @@ private slots:
     void onFilterToggled(bool);
     void onFilterTextChanged(const QString &text);
     void onQRCodeCapturerResultFound(const QString &uri);
+    void onSingleInstanceConnect();
 
 protected slots:
     void hideEvent(QHideEvent *e);


### PR DESCRIPTION
Using QSharedMemory to implement single instance has the culprit that if the application crashes, user may have to manually delete tmp files to start a new one, as stated in the README. That's why I choose to use  QLocalSocket instead. Even if the application crashed, new ones can still start without manually deleting  files.Tested on Linux x64. And I don't have a Mac, so it's not tested on that platform.