### PR TITLE
change libqtshadowsocks depends version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9),
                cmake (>= 3.1.0) | cmake3 (>= 3.1.0),
                qtbase5-dev,
                libqrencode-dev,
-               libqtshadowsocks-dev (>= 2.0.0),
+               libqtshadowsocks-dev (>= 1.1.0),
                libzbar-dev,
                libbotan1.10-dev
 Standards-Version: 3.9.6
@@ -18,7 +18,7 @@ Vcs-Browser: https://github.com/librehat/shadowsocks-qt5
 Package: shadowsocks-qt5
 Architecture: any
 Depends: ${shlibs:Depends},
-         libqtshadowsocks (>= 2.0.0)
+         libqtshadowsocks (>= 1.1.0)
 Description: A cross-platform shadowsocks GUI client
  Shadowsocks-Qt5 is a native and cross-platform shadowsocks GUI client
  with advanced features.


### PR DESCRIPTION
The new version of libqtshadowsocks-dev is 1.1.0, but the depends version of it must >= 2.0.0 