### PR TITLE
fix #328

### DIFF
--- a/src/urihelper.cpp
+++ b/src/urihelper.cpp
@@ -28,7 +28,7 @@ QString URIHelper::decodeImage(const QImage &img)
 
     //use zbar to decode the QR code
     zbar::ImageScanner scanner;
-    zbar::Image image(gimg.width(), gimg.height(), "Y800", gimg.bits(), gimg.byteCount());
+    zbar::Image image(gimg.bytesPerLine(), gimg.height(), "Y800", gimg.bits(), gimg.byteCount());
     scanner.scan(image);
     zbar::SymbolSet res_set = scanner.get_results();
     for (zbar::SymbolIterator it = res_set.symbol_begin(); it != res_set.symbol_end(); ++it) {


### PR DESCRIPTION
I find that this is not the problem of ZBar. Even though each pixel is represanted by 1 byte in QImage, the results of width() and bytesPerLine() is not always equal. In all conditions during my tests, when bytesPerLine() is not equal to width(),  bytesPerLine() will is equal to width() + 2.  I suppose that this is due to the hardware-independent image representation in the implement of QImage. 

But it is for sure that bytesPerLine() is equal to byteCount() / height().  And Since we use 1 byte for each pixel, replace width() with bytesPerLine() can solve the problem. 
